### PR TITLE
feat: add support for max_current_soft

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "0.1.15"
+VERSION = "0.1.16"
 
 
 setup(

--- a/tests/fixtures/v4_json/config.json
+++ b/tests/fixtures/v4_json/config.json
@@ -2,6 +2,7 @@
     "firmware": "7.1.3",
     "protocol": "-",
     "espflash": 4194304,
+    "wifi_serial": "1234567890AB",
     "version": "4.0.0",
     "diodet": 0,
     "gfcit": 0,
@@ -12,6 +13,9 @@
     "service": 2,
     "scale": 220,
     "offset": 0,
+    "max_current_soft": 6,
+    "min_current_hard": 6,
+    "max_current_hard": 48,    
     "mqtt_supported_protocols": [
       "mqtt",
       "mqtts"


### PR DESCRIPTION
Add support for the following new config entries in the firmware `v4.1.2` JSON reply:
max_current_soft
min_current_hard
max_current_hard

Adds new function `set_current` to set the `max_current_soft` setting.