### PR TITLE
Missing plain/text http header in set_divert_mode

### DIFF
--- a/openevsehttp/__main__.py
+++ b/openevsehttp/__main__.py
@@ -876,19 +876,20 @@ class OpenEVSE:
     async def set_divert_mode(self, mode: str = "fast") -> None:
         """Set the divert mode."""
         url = f"{self.url}divertmode"
-
         if mode not in ["fast", "eco"]:
-            _LOGGER.error("Invalid value for charge_mode: %s", mode)
+            _LOGGER.error("Invalid value for divert mode: %s", mode)
             raise ValueError
-
         _LOGGER.debug("Setting divert mode to %s", mode)
-
         # convert text to int
         new_mode = divert_mode[mode]
-        data = "divertmode=" + str(new_mode)
+        data = f"divertmode={new_mode}"
+        
+        # Use text/plain content type for the request
+        headers = {"Content-Type": "text/plain"}
+        
         response = await self.process_request(
-            url=url, method="post", data=data
-        )  # noqa: E501
+            url=url, method="post", data=data, headers=headers
+        )
         if response != "Divert Mode changed":
             _LOGGER.error("Problem issuing command: %s", response)
             raise UnknownError

--- a/openevsehttp/__main__.py
+++ b/openevsehttp/__main__.py
@@ -885,7 +885,7 @@ class OpenEVSE:
 
         # convert text to int
         new_mode = divert_mode[mode]
-        data = {"divertmode": new_mode}
+        data = "divertmode" + str(new_mode)
         response = await self.process_request(
             url=url, method="post", data=data
         )  # noqa: E501

--- a/openevsehttp/__main__.py
+++ b/openevsehttp/__main__.py
@@ -885,7 +885,7 @@ class OpenEVSE:
 
         # convert text to int
         new_mode = divert_mode[mode]
-        data = "divertmode" + str(new_mode)
+        data = "divertmode=" + str(new_mode)
         response = await self.process_request(
             url=url, method="post", data=data
         )  # noqa: E501

--- a/openevsehttp/__main__.py
+++ b/openevsehttp/__main__.py
@@ -884,7 +884,7 @@ class OpenEVSE:
         new_mode = divert_mode[mode]
 
         data = f"divertmode={new_mode}"
-        
+
         response = await self.process_request(
             url=url, method="post", rapi=data
         )

--- a/openevsehttp/__main__.py
+++ b/openevsehttp/__main__.py
@@ -885,9 +885,6 @@ class OpenEVSE:
 
         data = f"divertmode={new_mode}"
         
-        # Use text/plain content type for the request
-        headers = {"Content-Type": "text/plain"}
-        
         response = await self.process_request(
             url=url, method="post", rapi=data
         )

--- a/openevsehttp/__main__.py
+++ b/openevsehttp/__main__.py
@@ -889,7 +889,7 @@ class OpenEVSE:
         headers = {"Content-Type": "text/plain"}
         
         response = await self.process_request(
-            url=url, method="post", data=data, headers=headers
+            url=url, method="post", rapi=data
         )
         if response != "Divert Mode changed":
             _LOGGER.error("Problem issuing command: %s", response)

--- a/openevsehttp/__main__.py
+++ b/openevsehttp/__main__.py
@@ -885,9 +885,7 @@ class OpenEVSE:
 
         data = f"divertmode={new_mode}"
 
-        response = await self.process_request(
-            url=url, method="post", rapi=data
-        )
+        response = await self.process_request(url=url, method="post", rapi=data)
         if response != "Divert Mode changed":
             _LOGGER.error("Problem issuing command: %s", response)
             raise UnknownError

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2195,7 +2195,7 @@ async def test_set_divert_mode(
     with pytest.raises(ValueError):
         with caplog.at_level(logging.DEBUG):
             await test_charger_new.set_divert_mode("test")
-    assert "Invalid value for charge_mode: test" in caplog.text
+    assert "Invalid value for divert mode: test" in caplog.text
 
     mock_aioclient.post(
         TEST_URL_DIVERT,


### PR DESCRIPTION
still fix for [#451](https://github.com/firstof9/openevse/issues/451)

