### PR TITLE
Add explicit permissions to workflows to resolve security alerts

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published, prereleased]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-publish:
     name: Builds and publishes releases to PyPI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ on:
       - main
       - dev
 
+permissions: read-all
+
 jobs:
   prek:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds explicit permissions to all GitHub Actions workflows to resolve security alerts and adhere to the principle of least privilege.

### Changes:
- Added `permissions: read-all` to `test.yml`.
- Added `permissions: contents: read` to `publish-to-pypi.yml`.
- Verified existing explicit permissions in `release-drafter.yml` and `links.yml`.

By explicitly defining these permissions, we prevent workflows from inheriting overly broad default permissions, which is a common security recommendation.