### PR TITLE
Fix PreK CI failure on main branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install prek
         run: pip install prek==0.4.0
       - name: Run prek
-        run: prek run --all-files
+        run: prek run --all-files --skip no-commit-to-branch
   build:
     runs-on: ubuntu-latest
     needs: prek


### PR DESCRIPTION
This PR fixes a CI failure where the `prek` workflow would fail on the `main` branch because of the `no-commit-to-branch` hook.

The `no-commit-to-branch` hook is intended for local development to prevent accidental direct commits to protected branches. However, in CI, specifically during merge commits or push events to `main`, this hook triggers and fails.

I have updated the `test.yml` workflow to explicitly skip this hook when running `prek`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal test workflow configuration to modify the execution of testing checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/python-openevse-http/pull/568)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->