### PR TITLE
fix: update shaper command API parameters, track status, and bump to 0.3.3

### DIFF
--- a/openevsehttp/client.py
+++ b/openevsehttp/client.py
@@ -139,7 +139,7 @@ class OpenEVSE(CommandsMixin, ManagersMixin, SensorsMixin, PropertiesMixin):
                 try:
                     message = json.loads(message)
                 except ValueError:
-                    _LOGGER.warning("Non JSON response: %s", message)
+                    _LOGGER.debug("Non JSON response: %s", message)
 
                 if resp.status == 400:
                     if isinstance(message, dict) and "msg" in message:

--- a/openevsehttp/commands.py
+++ b/openevsehttp/commands.py
@@ -492,6 +492,8 @@ class CommandsMixin:
             _LOGGER.error("Problem issuing command: %s", response)
             raise UnknownError
 
+        self._status["divertmode"] = new_mode
+
     async def set_shaper(self, enable: bool = True) -> None:
         """Set shaper mode."""
         if not self._version_check("4.0.0"):
@@ -500,15 +502,17 @@ class CommandsMixin:
 
         url = f"{self.url}shaper"
         mode = 1 if enable else 0
-        data = {"mode": mode}
+        data = {"shaper": mode}
 
         _LOGGER.debug("Setting shaper to %s", mode)
-        response = await self.process_request(url=url, method="post", data=data)
+        response = await self.process_request(url=url, method="post", rapi=data)
         response = self._normalize_response(response)
         msg = response.get("msg") if isinstance(response, Mapping) else None
         if msg not in ["OK", "done", "no change", "Current Shaper state changed"]:
             _LOGGER.error("Problem issuing command: %s", response)
             raise UnknownError
+
+        self._status["shaper"] = mode
 
     async def toggle_shaper(self) -> None:
         """Toggle shaper mode."""

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "0.3.2"
+VERSION = "0.3.3"
 
 setup(
     name="python_openevse_http",

--- a/tests/test_shaper.py
+++ b/tests/test_shaper.py
@@ -46,6 +46,33 @@ async def test_set_shaper_fail(test_charger, mock_aioclient, caplog):
         await test_charger.set_shaper(True)
 
 
+async def test_set_shaper_non_json(test_charger, mock_aioclient, caplog):
+    """Test set_shaper with a non-JSON response."""
+    await test_charger.update()
+    test_charger._status["shaper"] = 0
+
+    mock_aioclient.post(
+        TEST_URL_SHAPER,
+        status=200,
+        body="Current Shaper state changed",
+    )
+    with caplog.at_level(logging.DEBUG):
+        await test_charger.set_shaper(True)
+        assert "Setting shaper to 1" in caplog.text
+        assert test_charger.shaper_active == 1
+
+    test_charger._status["shaper"] = 1
+    mock_aioclient.post(
+        TEST_URL_SHAPER,
+        status=200,
+        body="Current Shaper state changed",
+    )
+    with caplog.at_level(logging.DEBUG):
+        await test_charger.set_shaper(False)
+        assert "Setting shaper to 0" in caplog.text
+        assert test_charger.shaper_active == 0
+
+
 async def test_toggle_shaper(test_charger, mock_aioclient, caplog):
     """Test toggle_shaper command."""
     await test_charger.update()


### PR DESCRIPTION
This PR includes the latest updates for `python-openevse-http`:

### Highlights
- **Fix**: Updated `set_shaper` command parameters to use `{"shaper": mode}` instead of `{"mode": mode}` and process the request via RAPI parameters (`rapi=data`) to resolve shaper activation issues on OpenEVSE chargers.
- **Feature**: Added status tracking to automatically sync the local client state (`divertmode` and `shaper`) when issuing mode-change commands.
- **Chore**: Bumped the library version in `setup.py` to `0.3.3`.

### Details
- Updates `openevsehttp/commands.py` `set_shaper` to send a POST request with RAPI data.
- Automatically stores updated state on `set_shaper` and `set_divert_mode`.
- Suppresses noise by lowering warnings for non-JSON responses to `DEBUG` level.
- Adds mock tests in `tests/test_shaper.py` to cover non-JSON status updates.