### PR TITLE
Adjust version checking logging levels to debug

### DIFF
--- a/openevsehttp/client.py
+++ b/openevsehttp/client.py
@@ -438,7 +438,7 @@ class OpenEVSE(CommandsMixin, ManagersMixin, SensorsMixin, PropertiesMixin):
         """Return bool if minimum version is met."""
         if "version" not in self._config:
             # Throw warning if we can't find the version
-            _LOGGER.warning("Unable to find firmware version.")
+            _LOGGER.debug("Unable to find firmware version.")
             return False
         cutoff = AwesomeVersion(min_version)
         limit = ""
@@ -447,10 +447,10 @@ class OpenEVSE(CommandsMixin, ManagersMixin, SensorsMixin, PropertiesMixin):
 
         current = get_awesome_version(self._config["version"])
         if current.strategy == "unknown":
-            _LOGGER.warning(
-                "Non-standard versioning string: %s", self._config["version"]
+            _LOGGER.debug(
+                "Non-semver firmware version detected: %s",
+                self._config["version"],
             )
-            _LOGGER.debug("Non-semver firmware version detected.")
             return False
 
         if limit:

--- a/openevsehttp/commands.py
+++ b/openevsehttp/commands.py
@@ -358,7 +358,7 @@ class CommandsMixin:
         """Return the latest firmware version."""
         if "version" not in self._config:
             # Throw warning if we can't find the version
-            _LOGGER.warning("Unable to find firmware version.")
+            _LOGGER.debug("Unable to find firmware version.")
             return None
         base_url = "https://api.github.com/repos/OpenEVSE/"
         url = None
@@ -376,7 +376,7 @@ class CommandsMixin:
             else:
                 url = f"{base_url}ESP8266_WiFi_v2.x/releases/latest"
         except AwesomeVersionCompareException:
-            _LOGGER.warning("Non-semver firmware version detected.")
+            _LOGGER.debug("Non-semver firmware version detected.")
             return None
 
         try:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -365,7 +365,7 @@ async def test_firmware_check(
     with caplog.at_level(logging.DEBUG):
         firmware = await test_charger_unknown_semver.firmware_check()
         assert "Using version: random_a4f11e" in caplog.text
-        assert "Non-semver firmware version detected." in caplog.text
+        assert "Non-semver firmware version detected" in caplog.text
         assert firmware is None
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -452,7 +452,7 @@ async def test_set_divertmode(
     with pytest.raises(UnsupportedFeature):
         with caplog.at_level(logging.DEBUG):
             await test_charger_unknown_semver.divert_mode()
-    assert "Non-semver firmware version detected." in caplog.text
+    assert "Non-semver firmware version detected" in caplog.text
 
 
 async def test_set_divertmode_dict(test_charger_new, mock_aioclient):


### PR DESCRIPTION
This PR updates version-checking and firmware parsing log messages from `WARNING` to `DEBUG` level. 

### Changes
* `openevsehttp/client.py`:
  * Changes `"Unable to find firmware version."` from warning to debug.
  * Consolidates non-semver checking logs into a single debug log message: `"Non-semver firmware version detected: %s"`.
* `openevsehttp/commands.py`:
  * Changes `"Unable to find firmware version."` from warning to debug.
  * Changes `"Non-semver firmware version detected."` under `AwesomeVersionCompareException` from warning to debug.
* `tests/`:
  * Updates existing test assertions in `test_client.py` and `test_commands.py` to match the updated debug log string (without the trailing dot).

These changes eliminate verbose log spamming on integration startup or when utilizing custom firmware versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined logging behavior for firmware version checks. Detection of missing or non-standard firmware versions now logs at debug level instead of warning level. This reduces non-critical warning messages in standard logs while preserving comprehensive diagnostic information in debug output for advanced troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/python-openevse-http/pull/574?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->