### PR TITLE
fix: add support for custom firmware success messages in manual overrides

### DIFF
--- a/openevsehttp/commands.py
+++ b/openevsehttp/commands.py
@@ -12,7 +12,7 @@ from aiohttp.client_exceptions import ContentTypeError, ServerTimeoutError
 from awesomeversion import AwesomeVersion
 from awesomeversion.exceptions import AwesomeVersionCompareException
 
-from .const import MAX_AMPS, MIN_AMPS, RAPI_ERRORS, divert_mode
+from .const import MAX_AMPS, MIN_AMPS, RAPI_ERRORS, SUCCESS_ANSWERS, divert_mode
 from .exceptions import UnknownError, UnsupportedFeature
 from .utils import get_awesome_version
 
@@ -68,7 +68,7 @@ class CommandsMixin:
         response = await self.process_request(url=url, method="post", data=data)
         response = self._normalize_response(response)
         msg = response.get("msg") if isinstance(response, Mapping) else None
-        if msg not in ["OK", "done", "no change"]:
+        if msg not in SUCCESS_ANSWERS:
             _LOGGER.error("Problem issuing command: %s", response)
             raise UnknownError
 
@@ -95,11 +95,10 @@ class CommandsMixin:
         response = await self.process_request(url=url, method="post", data=data)
         _LOGGER.debug("divert_mode response: %s", response)
         normalized_response = self._normalize_response(response)
-        if isinstance(normalized_response, dict) and normalized_response.get("msg") in [
-            "OK",
-            "done",
-            "no change",
-        ]:
+        if (
+            isinstance(normalized_response, dict)
+            and normalized_response.get("msg") in SUCCESS_ANSWERS
+        ):
             self._config["divert_enabled"] = mode
         return normalized_response
 
@@ -172,11 +171,10 @@ class CommandsMixin:
             response = await self.process_request(url=url, method="patch")
             response = self._normalize_response(response)
             _LOGGER.debug("Toggle response: %s", response)
-            if not isinstance(response, Mapping) or response.get("msg") not in [
-                "OK",
-                "done",
-                "no change",
-            ]:
+            if (
+                not isinstance(response, Mapping)
+                or response.get("msg") not in SUCCESS_ANSWERS
+            ):
                 _LOGGER.error("Problem toggling override: %s", response)
                 raise RuntimeError(f"Failed to toggle override: {response}")
         else:
@@ -210,7 +208,7 @@ class CommandsMixin:
         response = self._normalize_response(response)
         msg = response.get("msg") if isinstance(response, Mapping) else None
         _LOGGER.debug("Clear override response: %s", msg)
-        if msg not in ["OK", "done", "no change"]:
+        if msg not in SUCCESS_ANSWERS:
             _LOGGER.error("Problem clearing override: %s", response)
             raise RuntimeError(f"Failed to clear override: {response}")
 
@@ -236,11 +234,10 @@ class CommandsMixin:
             _LOGGER.debug("Setting current limit to %s", amps)
             response = await self.set_override(charge_current=amps)
             _LOGGER.debug("Set current response: %s", response)
-            if not isinstance(response, Mapping) or response.get("msg") not in [
-                "OK",
-                "done",
-                "no change",
-            ]:
+            if (
+                not isinstance(response, Mapping)
+                or response.get("msg") not in SUCCESS_ANSWERS
+            ):
                 _LOGGER.error("Problem setting current limit: %s", response)
                 raise UnknownError
 
@@ -275,7 +272,7 @@ class CommandsMixin:
         response = self._normalize_response(response)
         _LOGGER.debug("service response: %s", response)
         msg = response.get("msg") if isinstance(response, Mapping) else None
-        if msg not in ["OK", "done", "no change"]:
+        if msg not in SUCCESS_ANSWERS:
             _LOGGER.error("Problem issuing command: %s", response)
             raise UnknownError
 
@@ -448,7 +445,7 @@ class CommandsMixin:
         response = await self.process_request(url=url, method="post", data=data)
         response = self._normalize_response(response)
         msg = response.get("msg") if isinstance(response, Mapping) else None
-        if msg not in ["OK", "done", "no change"]:
+        if msg not in SUCCESS_ANSWERS:
             _LOGGER.error("Problem issuing command: %s", response)
             raise UnknownError
 
@@ -470,11 +467,7 @@ class CommandsMixin:
             res_lower = response.lower()
             if "divert" in res_lower and "changed" in res_lower:
                 success = True
-        elif isinstance(response, dict) and response.get("msg") in [
-            "OK",
-            "done",
-            "no change",
-        ]:
+        elif isinstance(response, dict) and response.get("msg") in SUCCESS_ANSWERS:
             success = True
 
         if not success:
@@ -497,7 +490,7 @@ class CommandsMixin:
         response = await self.process_request(url=url, method="post", rapi=data)
         response = self._normalize_response(response)
         msg = response.get("msg") if isinstance(response, Mapping) else None
-        if msg not in ["OK", "done", "no change", "Current Shaper state changed"]:
+        if msg not in SUCCESS_ANSWERS and msg != "Current Shaper state changed":
             _LOGGER.error("Problem issuing command: %s", response)
             raise UnknownError
 

--- a/openevsehttp/const.py
+++ b/openevsehttp/const.py
@@ -60,3 +60,5 @@ RAPI_ERRORS = [
     "RAPI_RESPONSE_BLOCKED",
     "RAPI_RESPONSE_INVALID_COMMAND",
 ]
+
+SUCCESS_ANSWERS = ["OK", "done", "no change", "Created", "Updated", "Deleted"]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -177,6 +177,54 @@ async def test_toggle_override_fail(test_charger, mock_aioclient, caplog):
     assert "Problem toggling override: {'msg': 'failure!'}" in caplog.text
 
 
+async def test_custom_override_success_responses(test_charger, mock_aioclient, caplog):
+    """Test override methods accept firmware-specific response strings ("Created", "Updated", "Deleted")."""
+    await test_charger.update()
+
+    # 1. toggle_override with "Updated"
+    mock_aioclient.patch(
+        TEST_URL_OVERRIDE,
+        status=200,
+        body='{"msg": "Updated"}',
+    )
+    with caplog.at_level(logging.DEBUG):
+        await test_charger.toggle_override()
+    assert "Toggling manual override http" in caplog.text
+
+    # 2. clear_override with "Deleted"
+    mock_aioclient.delete(
+        TEST_URL_OVERRIDE,
+        status=200,
+        body='{"msg": "Deleted"}',
+    )
+    with caplog.at_level(logging.DEBUG):
+        await test_charger.clear_override()
+    assert "Clearing manual override http" in caplog.text
+
+    # 3. set_current / set_override with "Created"
+    value = {
+        "state": "active",
+        "charge_current": 0,
+        "max_current": 0,
+        "energy_limit": 0,
+        "time_limit": 0,
+        "auto_release": True,
+    }
+    mock_aioclient.get(
+        TEST_URL_OVERRIDE,
+        status=200,
+        body=json.dumps(value),
+    )
+    mock_aioclient.post(
+        TEST_URL_OVERRIDE,
+        status=200,
+        body='{"msg": "Created"}',
+    )
+    with caplog.at_level(logging.DEBUG):
+        await test_charger.set_current(16)
+    assert "Setting current limit to 16" in caplog.text
+
+
 async def test_toggle_override_refresh_fail(mock_aioclient, caplog):
     """Test toggle_override when state is missing and refresh fails."""
     # Use a fresh charger to avoid fixture mock interference


### PR DESCRIPTION
This PR resolves issues (such as firstof9/openevse#616) where setting, toggling, or clearing manual overrides fails because the OpenEVSE firmware returns specific success messages ("Created", "Updated", "Deleted") instead of the generic success strings ("OK", "done", "no change"). We introduce a central SUCCESS_ANSWERS constant in const.py and use it to validate responses in commands.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced device compatibility by improving response handling to recognize firmware-specific success message variations, supporting a wider range of device firmware versions.
  * Standardized success response validation across all command operations for consistent and reliable command execution verification.
  * Improved overall system stability through centralized success message handling logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/python-openevse-http/pull/582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->