### PR TITLE
chore(ci): update release drafter with version resolver and autolabeler

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,3 +6,21 @@ categories:
 template: |
   ## What’s Changed
   $CHANGES
+
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+version-resolver:
+  major:
+    labels:
+      - "major"
+      - "breaking change"
+  minor:
+    labels:
+      - "minor"
+      - "feature"
+  patch:
+    labels:
+      - "patch"
+      - "bug"
+      - "fix"
+  default: patch

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,26 +1,103 @@
-change-template: "- #$NUMBER - $TITLE (@$AUTHOR)"
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+sort-direction: ascending
 categories:
-  - title: "⚠ Breaking Changes"
+  - title: "💥 Breaking Change 💥"
     labels:
+      - "breaking-change"
       - "breaking change"
-template: |
-  ## What’s Changed
-  $CHANGES
-
-name-template: 'v$RESOLVED_VERSION'
-tag-template: 'v$RESOLVED_VERSION'
+  - title: "✨ New Features ✨"
+    labels:
+      - "enhancement"
+      - "feature"
+  - title: "🐛 Bug Fixes 🐛"
+    labels:
+      - "fix"
+      - "bugfix"
+      - "bug"
+  - title: "⚡ Performance ⚡"
+    labels:
+      - "performance"
+  - title: "🔧 Maintenance 🔧"
+    labels:
+      - "chore"
+      - "documentation"
+      - "maintenance"
+      - "repo"
+      - "dependencies"
+      - "github_actions"
+      - "refactor"
+      - "style"
+      - "build"
+      - "revert"
+  - title: "🎓 Code Quality 🎓"
+    labels:
+      - "code-quality"
+      - "CI"
+      - "test"
+autolabeler:
+  - label: "breaking-change"
+    title:
+      - '/^[a-z]+(\([^)]+\))?!:/i'
+  - label: "feature"
+    title:
+      - '/^feat(\([^)]+\))?:/i'
+  - label: "bugfix"
+    title:
+      - '/^fix(\([^)]+\))?:/i'
+  - label: "refactor"
+    title:
+      - '/^refactor(\([^)]+\))?:/i'
+  - label: "code-quality"
+    title:
+      - '/^test(\([^)]+\))?:/i'
+  - label: "CI"
+    title:
+      - '/^ci(\([^)]+\))?:/i'
+  - label: "chore"
+    title:
+      - '/^chore(\([^)]+\))?:/i'
+  - label: "documentation"
+    title:
+      - '/^docs(\([^)]+\))?:/i'
+  - label: "style"
+    title:
+      - '/^style(\([^)]+\))?:/i'
+  - label: "performance"
+    title:
+      - '/^perf(\([^)]+\))?:/i'
+  - label: "revert"
+    title:
+      - '/^revert(\([^)]+\))?:/i'
+  - label: "build"
+    title:
+      - '/^build(\([^)]+\))?:/i'
 version-resolver:
   major:
     labels:
-      - "major"
+      - "breaking-change"
       - "breaking change"
   minor:
     labels:
-      - "minor"
       - "feature"
+      - "enhancement"
   patch:
     labels:
-      - "patch"
       - "bug"
       - "fix"
+      - "bugfix"
+      - "performance"
+      - "refactor"
+      - "style"
+      - "build"
+      - "chore"
+      - "documentation"
+      - "CI"
+      - "test"
+      - "code-quality"
+      - "revert"
   default: patch
+template: |
+  ## What’s Changed
+  $CHANGES


### PR DESCRIPTION
This PR configures release-drafter to handle semantic versioning resolution. It adds name-template, tag-template, and version-resolver configs to suggest the next major, minor, or patch release version automatically based on the PR labels.