### PR TITLE
build: migrate build system and setup.py to setuptools-scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,9 @@ ignore = [
 
 [tool.ruff.lint.mccabe]
 max-complexity = 18
+
+[build-system]
+requires = ["setuptools>=61.0.0", "setuptools-scm>=8.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,10 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "0.3.4"
 
 setup(
     name="python_openevse_http",
-    version=VERSION,
+    use_scm_version=True,
     url="https://github.com/firstof9/python-openevse-http",
     download_url="https://github.com/firstof9/python-openevse-http",
     author="firstof9",


### PR DESCRIPTION
This PR migrates python-openevse-http's build system and package version configuration from a static string in setup.py to setuptools-scm. This resolves the project version dynamically from Git tags, eliminating the need to manually update setup.py before publishing new releases.