### PR TITLE
chore(ci): add manual trigger to PyPI workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -3,6 +3,7 @@ name: Publish releases to PyPI
 on:
   release:
     types: [published, prereleased]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds `workflow_dispatch` to `.github/workflows/publish-to-pypi.yml` to allow manual triggering of PyPI releases.