### PR TITLE
chore(ci): fix PyPI release workflow tag resolution and add manual tag dispatch

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [published, prereleased]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag/Ref to build and publish'
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -18,6 +23,9 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+          fetch-depth: 0
       - name: Set up Python 3.9
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:


### PR DESCRIPTION
Fixes PyPI build/push release tags not being resolved correctly by setuptools_scm by fetching all tags (`fetch-depth: 0`), and adds a manual `tag` input option to `workflow_dispatch` trigger.