### PR TITLE
Add firmware update support

### DIFF
--- a/openevsehttp/commands.py
+++ b/openevsehttp/commands.py
@@ -447,6 +447,13 @@ class CommandsMixin:
         2. Pass firmware_url to tell the device to download the file directly.
         3. Pass neither to automatically resolve the latest matching binary URL from GitHub.
         """
+        if firmware_bytes is not None and firmware_url is not None:
+            raise ValueError("Cannot specify both firmware_bytes and firmware_url")
+
+        if firmware_url is not None:
+            if not isinstance(firmware_url, str) or not firmware_url.strip():
+                raise ValueError("Invalid firmware_url")
+
         url = f"{self.url}update"
 
         # 1. Handle multipart binary upload
@@ -465,7 +472,7 @@ class CommandsMixin:
             return await self.process_request(url=url, method="post", rapi=form_data)
 
         # 2. Resolve URL from GitHub if not specified
-        if not firmware_url:
+        if firmware_url is None:
             check_result = await self.firmware_check()
             if not check_result or not check_result.get("browser_download_url"):
                 raise RuntimeError(

--- a/openevsehttp/commands.py
+++ b/openevsehttp/commands.py
@@ -414,11 +414,71 @@ class CommandsMixin:
 
             if not isinstance(message, dict):
                 return None
+
+            # Match browser_download_url based on buildenv
+            download_url = None
+            buildenv = self._config.get("buildenv")
+            assets = message.get("assets", [])
+
+            if buildenv and assets:
+                target_filename = f"{buildenv}.bin"
+                for asset in assets:
+                    if asset.get("name") == target_filename:
+                        download_url = asset.get("browser_download_url")
+                        break
+
             return {
                 "latest_version": message.get("tag_name"),
                 "release_notes": message.get("body"),
                 "release_url": message.get("html_url"),
+                "browser_download_url": download_url,
             }
+
+    async def update_firmware(
+        self,
+        firmware_url: str | None = None,
+        firmware_bytes: bytes | None = None,
+        filename: str = "firmware.bin",
+    ) -> Mapping[str, Any] | list[Any] | str:
+        """Instruct the device to update its firmware.
+
+        You can either:
+        1. Pass firmware_bytes to perform a multipart upload of a local file.
+        2. Pass firmware_url to tell the device to download the file directly.
+        3. Pass neither to automatically resolve the latest matching binary URL from GitHub.
+        """
+        url = f"{self.url}update"
+
+        # 1. Handle multipart binary upload
+        if firmware_bytes is not None:
+            data = aiohttp.FormData()
+            data.add_field(
+                name="file",
+                value=firmware_bytes,
+                filename=filename,
+                content_type="application/octet-stream",
+            )
+            _LOGGER.debug(
+                "Uploading firmware binary to %s (%d bytes)", url, len(firmware_bytes)
+            )
+            # Rapi is mapped to http request's data kwarg in process_request
+            return await self.process_request(url=url, method="post", rapi=data)
+
+        # 2. Resolve URL from GitHub if not specified
+        if not firmware_url:
+            check_result = await self.firmware_check()
+            if not check_result or not check_result.get("browser_download_url"):
+                raise RuntimeError(
+                    "Could not resolve latest firmware download URL from GitHub."
+                )
+            firmware_url = check_result["browser_download_url"]
+
+        # 3. Post JSON URL payload
+        data = {"url": firmware_url}
+        _LOGGER.debug(
+            "Requesting OpenEVSE to download and update from: %s", firmware_url
+        )
+        return await self.process_request(url=url, method="post", data=data)
 
     async def set_led_brightness(self, level: int) -> None:
         """Set LED brightness level."""

--- a/openevsehttp/commands.py
+++ b/openevsehttp/commands.py
@@ -451,8 +451,8 @@ class CommandsMixin:
 
         # 1. Handle multipart binary upload
         if firmware_bytes is not None:
-            data = aiohttp.FormData()
-            data.add_field(
+            form_data = aiohttp.FormData()
+            form_data.add_field(
                 name="file",
                 value=firmware_bytes,
                 filename=filename,
@@ -462,7 +462,7 @@ class CommandsMixin:
                 "Uploading firmware binary to %s (%d bytes)", url, len(firmware_bytes)
             )
             # Rapi is mapped to http request's data kwarg in process_request
-            return await self.process_request(url=url, method="post", rapi=data)
+            return await self.process_request(url=url, method="post", rapi=form_data)
 
         # 2. Resolve URL from GitHub if not specified
         if not firmware_url:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1150,3 +1150,25 @@ async def test_update_firmware_auto_missing_buildenv(test_charger, mock_aioclien
         match="Could not resolve latest firmware download URL from GitHub.",
     ):
         await test_charger.update_firmware()
+
+
+async def test_update_firmware_both_provided(test_charger):
+    """Test update_firmware raises ValueError when both bytes and URL are provided."""
+    with pytest.raises(
+        ValueError, match="Cannot specify both firmware_bytes and firmware_url"
+    ):
+        await test_charger.update_firmware(
+            firmware_url="http://url", firmware_bytes=b"bytes"
+        )
+
+
+async def test_update_firmware_url_invalid(test_charger):
+    """Test update_firmware raises ValueError when firmware_url is empty or invalid type."""
+    with pytest.raises(ValueError, match="Invalid firmware_url"):
+        await test_charger.update_firmware(firmware_url="")
+
+    with pytest.raises(ValueError, match="Invalid firmware_url"):
+        await test_charger.update_firmware(firmware_url="   ")
+
+    with pytest.raises(ValueError, match="Invalid firmware_url"):
+        await test_charger.update_firmware(firmware_url=123)  # type: ignore

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1040,3 +1040,113 @@ async def test_normalize_response(test_charger):
     assert test_charger._normalize_response({"msg": "OK"}) == {"msg": "OK"}
     # Test with string
     assert test_charger._normalize_response("OK") == {"msg": "OK"}
+
+
+# ── update_firmware ──────────────────────────────────────────────────
+
+
+async def test_update_firmware_bytes(test_charger, mock_aioclient, caplog):
+    """Test update_firmware with bytes upload."""
+    mock_aioclient.post(
+        "http://openevse.test.tld/update",
+        status=200,
+        body="OK",
+    )
+    with caplog.at_level(logging.DEBUG):
+        response = await test_charger.update_firmware(firmware_bytes=b"fakebinarydata")
+        assert response == "OK"
+        assert (
+            "Uploading firmware binary to http://openevse.test.tld/update (14 bytes)"
+            in caplog.text
+        )
+
+
+async def test_update_firmware_url(test_charger, mock_aioclient, caplog):
+    """Test update_firmware with a direct URL."""
+    mock_aioclient.post(
+        "http://openevse.test.tld/update",
+        status=200,
+        body='{"msg":"started"}',
+    )
+    with caplog.at_level(logging.DEBUG):
+        response = await test_charger.update_firmware(
+            firmware_url="http://github.com/release.bin"
+        )
+        assert response == {"msg": "started"}
+        assert (
+            "Requesting OpenEVSE to download and update from: http://github.com/release.bin"
+            in caplog.text
+        )
+
+
+async def test_update_firmware_auto(test_charger, mock_aioclient, caplog):
+    """Test update_firmware with auto-resolved URL from GitHub."""
+    # Setup config with a buildenv
+    test_charger._config = {"version": "4.0.1", "buildenv": "openevse_esp32-gateway"}
+
+    # Mock GitHub Releases API to return assets matching buildenv
+    github_response = {
+        "tag_name": "v4.1.2",
+        "body": "release notes",
+        "html_url": "https://github.com/OpenEVSE/releases/v4.1.2",
+        "assets": [
+            {
+                "name": "openevse_esp32-gateway.bin",
+                "browser_download_url": "https://github.com/OpenEVSE/releases/download/v4.1.2/openevse_esp32-gateway.bin",
+            },
+            {
+                "name": "other_env.bin",
+                "browser_download_url": "https://github.com/OpenEVSE/releases/download/v4.1.2/other_env.bin",
+            },
+        ],
+    }
+
+    mock_aioclient.get(
+        "https://api.github.com/repos/OpenEVSE/ESP32_WiFi_V4.x/releases/latest",
+        status=200,
+        body=json.dumps(github_response),
+    )
+
+    mock_aioclient.post(
+        "http://openevse.test.tld/update",
+        status=200,
+        body='{"msg":"started"}',
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        response = await test_charger.update_firmware()
+        assert response == {"msg": "started"}
+        assert (
+            "Requesting OpenEVSE to download and update from: https://github.com/OpenEVSE/releases/download/v4.1.2/openevse_esp32-gateway.bin"
+            in caplog.text
+        )
+
+
+async def test_update_firmware_auto_missing_buildenv(test_charger, mock_aioclient):
+    """Test update_firmware raises RuntimeError when buildenv asset is missing."""
+    test_charger._config = {"version": "4.0.1", "buildenv": "openevse_esp32-gateway"}
+
+    # Mock GitHub releases but without the matching gateway asset
+    github_response = {
+        "tag_name": "v4.1.2",
+        "body": "release notes",
+        "html_url": "https://github.com/OpenEVSE/releases/v4.1.2",
+        "assets": [
+            {
+                "name": "other_env.bin",
+                "browser_download_url": "https://github.com/OpenEVSE/releases/download/v4.1.2/other_env.bin",
+            }
+        ],
+    }
+
+    mock_aioclient.get(
+        "https://api.github.com/repos/OpenEVSE/ESP32_WiFi_V4.x/releases/latest",
+        status=200,
+        body=json.dumps(github_response),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Could not resolve latest firmware download URL from GitHub.",
+    ):
+        await test_charger.update_firmware()


### PR DESCRIPTION
This PR implements firmware update capabilities on OpenEVSE devices.

### Changes:
- Modified `_firmware_check_with_session` in `openevsehttp/commands.py` to resolve and return `browser_download_url` matching the device's `buildenv` from release assets.
- Added `update_firmware` to `CommandsMixin` supporting local binary upload (`firmware_bytes`), a download URL (`firmware_url`), or auto-resolving from GitHub releases (when neither is provided).
- Added comprehensive unit tests in `tests/test_commands.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added firmware update functionality supporting three methods: uploading bytes directly, providing an explicit firmware URL, or automatically resolving the latest matching firmware from releases.
  * Enhanced firmware check to include device-specific firmware download URL.

* **Tests**
  * Added comprehensive test coverage for firmware update including input validation and error handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->