### PR TITLE
fix(ota): version guard firmware updates and sync websocket telemetry

### DIFF
--- a/openevsehttp/client.py
+++ b/openevsehttp/client.py
@@ -344,6 +344,7 @@ class OpenEVSE(CommandsMixin, ManagersMixin, SensorsMixin, PropertiesMixin):
                     self._status["ota_update"] = 1
                 elif ota_val in ("completed", "failed"):
                     self._status["ota_update"] = 0
+                    data.pop("ota_progress", None)
                     self._status.pop("ota_progress", None)
 
             self._status.update(data)

--- a/openevsehttp/client.py
+++ b/openevsehttp/client.py
@@ -337,6 +337,15 @@ class OpenEVSE(CommandsMixin, ManagersMixin, SensorsMixin, PropertiesMixin):
             # TODO: update specific endpoints based on _version prefix
             if any(key in keys for key in UPDATE_TRIGGERS):
                 await self.update()
+
+            if "ota" in keys:
+                ota_val = data["ota"]
+                if ota_val == "started":
+                    self._status["ota_update"] = 1
+                elif ota_val in ("completed", "failed"):
+                    self._status["ota_update"] = 0
+                    self._status.pop("ota_progress", None)
+
             self._status.update(data)
 
             if self.callback is not None:

--- a/openevsehttp/commands.py
+++ b/openevsehttp/commands.py
@@ -447,6 +447,10 @@ class CommandsMixin:
         2. Pass firmware_url to tell the device to download the file directly.
         3. Pass neither to automatically resolve the latest matching binary URL from GitHub.
         """
+        if not self._version_check("4.1.7"):
+            _LOGGER.debug("Feature not supported for older firmware.")
+            raise UnsupportedFeature
+
         if firmware_bytes is not None and firmware_url is not None:
             raise ValueError("Cannot specify both firmware_bytes and firmware_url")
 

--- a/openevsehttp/properties.py
+++ b/openevsehttp/properties.py
@@ -341,7 +341,17 @@ class PropertiesMixin:
     @property
     def ota_update(self) -> bool:
         """Return if an OTA update is active."""
-        return self._status.get("ota_update", False)
+        return bool(self._status.get("ota_update", False))
+
+    @property
+    def ota_progress(self) -> int | None:
+        """Return the progress of the current OTA update."""
+        return self._status.get("ota_progress")
+
+    @property
+    def ota_state(self) -> str | None:
+        """Return the state of the current OTA update."""
+        return self._status.get("ota")
 
     @property
     def manual_override(self) -> bool:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1667,8 +1667,10 @@ async def test_update_status_ota():
     await charger._update_status("data", {"ota_progress": 25}, None)
     assert charger.ota_progress == 25
 
-    # 3. Completed event
-    await charger._update_status("data", {"ota": "completed"}, None)
+    # 3. Completed event (verifying ota_progress is cleared even if present in the data dict)
+    await charger._update_status(
+        "data", {"ota": "completed", "ota_progress": 100}, None
+    )
     assert charger.ota_update is False
     assert charger.ota_progress is None
     assert charger.ota_state == "completed"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1651,3 +1651,24 @@ async def test_update_status_non_mapping_data(caplog):
     with caplog.at_level(logging.WARNING):
         await charger._update_status("data", "not a dict", None)
     assert "Received non-Mapping websocket data: not a dict" in caplog.text
+
+
+async def test_update_status_ota():
+    """Test _update_status with ota websocket events."""
+    charger = OpenEVSE(SERVER_URL)
+    charger._status = {"ota_update": 0}
+
+    # 1. Started event
+    await charger._update_status("data", {"ota": "started"}, None)
+    assert charger.ota_update is True
+    assert charger.ota_state == "started"
+
+    # 2. Progress event
+    await charger._update_status("data", {"ota_progress": 25}, None)
+    assert charger.ota_progress == 25
+
+    # 3. Completed event
+    await charger._update_status("data", {"ota": "completed"}, None)
+    assert charger.ota_update is False
+    assert charger.ota_progress is None
+    assert charger.ota_state == "completed"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1047,6 +1047,7 @@ async def test_normalize_response(test_charger):
 
 async def test_update_firmware_bytes(test_charger, mock_aioclient, caplog):
     """Test update_firmware with bytes upload."""
+    test_charger._config["version"] = "4.1.7"
     mock_aioclient.post(
         "http://openevse.test.tld/update",
         status=200,
@@ -1063,6 +1064,7 @@ async def test_update_firmware_bytes(test_charger, mock_aioclient, caplog):
 
 async def test_update_firmware_url(test_charger, mock_aioclient, caplog):
     """Test update_firmware with a direct URL."""
+    test_charger._config["version"] = "4.1.7"
     mock_aioclient.post(
         "http://openevse.test.tld/update",
         status=200,
@@ -1081,8 +1083,8 @@ async def test_update_firmware_url(test_charger, mock_aioclient, caplog):
 
 async def test_update_firmware_auto(test_charger, mock_aioclient, caplog):
     """Test update_firmware with auto-resolved URL from GitHub."""
-    # Setup config with a buildenv
-    test_charger._config = {"version": "4.0.1", "buildenv": "openevse_esp32-gateway"}
+    # Setup config with a buildenv and version >= 4.1.7
+    test_charger._config = {"version": "4.1.7", "buildenv": "openevse_esp32-gateway"}
 
     # Mock GitHub Releases API to return assets matching buildenv
     github_response = {
@@ -1124,7 +1126,7 @@ async def test_update_firmware_auto(test_charger, mock_aioclient, caplog):
 
 async def test_update_firmware_auto_missing_buildenv(test_charger, mock_aioclient):
     """Test update_firmware raises RuntimeError when buildenv asset is missing."""
-    test_charger._config = {"version": "4.0.1", "buildenv": "openevse_esp32-gateway"}
+    test_charger._config = {"version": "4.1.7", "buildenv": "openevse_esp32-gateway"}
 
     # Mock GitHub releases but without the matching gateway asset
     github_response = {
@@ -1154,6 +1156,7 @@ async def test_update_firmware_auto_missing_buildenv(test_charger, mock_aioclien
 
 async def test_update_firmware_both_provided(test_charger):
     """Test update_firmware raises ValueError when both bytes and URL are provided."""
+    test_charger._config["version"] = "4.1.7"
     with pytest.raises(
         ValueError, match="Cannot specify both firmware_bytes and firmware_url"
     ):
@@ -1164,6 +1167,7 @@ async def test_update_firmware_both_provided(test_charger):
 
 async def test_update_firmware_url_invalid(test_charger):
     """Test update_firmware raises ValueError when firmware_url is empty or invalid type."""
+    test_charger._config["version"] = "4.1.7"
     with pytest.raises(ValueError, match="Invalid firmware_url"):
         await test_charger.update_firmware(firmware_url="")
 
@@ -1172,3 +1176,10 @@ async def test_update_firmware_url_invalid(test_charger):
 
     with pytest.raises(ValueError, match="Invalid firmware_url"):
         await test_charger.update_firmware(firmware_url=123)  # type: ignore
+
+
+async def test_update_firmware_unsupported(test_charger):
+    """Test update_firmware raises UnsupportedFeature on older firmware."""
+    test_charger._config["version"] = "4.1.2"
+    with pytest.raises(UnsupportedFeature):
+        await test_charger.update_firmware(firmware_url="http://url")

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1040,15 +1040,29 @@ async def test_get_has_limit(fixture, expected, request):
 
 
 @pytest.mark.parametrize(
-    "fixture, expected", [("test_charger", 0), ("test_charger_v2", 0)]
+    "fixture, expected", [("test_charger", False), ("test_charger_v2", False)]
 )
 async def test_get_ota_update(fixture, expected, request):
     """Test ota_update property."""
     charger = request.getfixturevalue(fixture)
     await charger.update()
     status = charger.ota_update
-    assert status == expected
+    assert status is expected
     await charger.ws_disconnect()
+
+
+async def test_ota_properties():
+    """Test ota_progress and ota_state properties."""
+    charger = OpenEVSE(SERVER_URL)
+    charger._status = {"ota_update": 1, "ota_progress": 45, "ota": "started"}
+    assert charger.ota_update is True
+    assert charger.ota_progress == 45
+    assert charger.ota_state == "started"
+
+    charger._status = {"ota_update": 0}
+    assert charger.ota_update is False
+    assert charger.ota_progress is None
+    assert charger.ota_state is None
 
 
 # ── MQTT ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

This PR addresses firmware update verification and state synchronization by:
1. Guarding the `update_firmware` method to only run on firmware versions `4.1.7` or higher (when the firmware introduced `ota_progress` and dynamic `ota` status tracking), raising an `UnsupportedFeature` exception on older versions.
2. Syncing `ota_update`, `ota_progress`, and `ota_state` dynamically when WebSocket updates containing `"ota"` events are received.
3. Ensuring that `ota_update` consistently returns a boolean value.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OTA progress and state properties for real-time monitoring of over-the-air updates
  * Device websocket connections now provide live OTA status updates

* **Improvements**
  * Firmware updates now require minimum device firmware version 4.1.7
<!-- end of auto-generated comment: release notes by coderabbit.ai -->