### PR TITLE
fix: status polling during active WebSocket and OTA updates (#597)

### DIFF
--- a/openevsehttp/client.py
+++ b/openevsehttp/client.py
@@ -183,12 +183,12 @@ class OpenEVSE(CommandsMixin, ManagersMixin, SensorsMixin, PropertiesMixin):
             return (False, "")
         return (value["cmd"], value["ret"])
 
-    async def update(self) -> None:
+    async def update(self, force_status: bool = False) -> None:
         """Update the values."""
         # TODO: add addiontal endpoints to update
         urls = [f"{self.url}config"]
 
-        if not self._ws_listening:
+        if not self._ws_listening or force_status or self.ota_update:
             urls = [f"{self.url}status", f"{self.url}config"]
 
         for url in urls:
@@ -196,7 +196,7 @@ class OpenEVSE(CommandsMixin, ManagersMixin, SensorsMixin, PropertiesMixin):
             response = await self.process_request(url, method="get")
             if "/status" in url:
                 if isinstance(response, Mapping) and "error" not in response:
-                    self._status = dict(response)
+                    self._status.update(dict(response))
                     _LOGGER.debug("Status update: %s", self._status)
                 elif isinstance(response, Mapping):
                     _LOGGER.warning(

--- a/openevsehttp/commands.py
+++ b/openevsehttp/commands.py
@@ -39,7 +39,7 @@ class CommandsMixin:
     async def send_command(self, command: str) -> tuple:
         raise NotImplementedError
 
-    async def update(self) -> None:
+    async def update(self, force_status: bool = False) -> None:
         raise NotImplementedError
 
     def _normalize_response(self, response: Any) -> dict[str, Any] | list[Any]:
@@ -473,7 +473,11 @@ class CommandsMixin:
                 "Uploading firmware binary to %s (%d bytes)", url, len(firmware_bytes)
             )
             # Rapi is mapped to http request's data kwarg in process_request
-            return await self.process_request(url=url, method="post", rapi=form_data)
+            response = await self.process_request(
+                url=url, method="post", rapi=form_data
+            )
+            self._status["ota_update"] = 1
+            return response
 
         # 2. Resolve URL from GitHub if not specified
         if firmware_url is None:
@@ -489,7 +493,9 @@ class CommandsMixin:
         _LOGGER.debug(
             "Requesting OpenEVSE to download and update from: %s", firmware_url
         )
-        return await self.process_request(url=url, method="post", data=data)
+        response = await self.process_request(url=url, method="post", data=data)
+        self._status["ota_update"] = 1
+        return response
 
     async def set_led_brightness(self, level: int) -> None:
         """Set LED brightness level."""

--- a/openevsehttp/commands.py
+++ b/openevsehttp/commands.py
@@ -476,7 +476,12 @@ class CommandsMixin:
             response = await self.process_request(
                 url=url, method="post", rapi=form_data
             )
-            self._status["ota_update"] = 1
+            normalized = self._normalize_response(response)
+            if isinstance(normalized, dict) and (
+                normalized.get("msg") == "started"
+                or normalized.get("msg") in SUCCESS_ANSWERS
+            ):
+                self._status["ota_update"] = 1
             return response
 
         # 2. Resolve URL from GitHub if not specified
@@ -494,7 +499,12 @@ class CommandsMixin:
             "Requesting OpenEVSE to download and update from: %s", firmware_url
         )
         response = await self.process_request(url=url, method="post", data=data)
-        self._status["ota_update"] = 1
+        normalized = self._normalize_response(response)
+        if isinstance(normalized, dict) and (
+            normalized.get("msg") == "started"
+            or normalized.get("msg") in SUCCESS_ANSWERS
+        ):
+            self._status["ota_update"] = 1
         return response
 
     async def set_led_brightness(self, level: int) -> None:

--- a/openevsehttp/commands.py
+++ b/openevsehttp/commands.py
@@ -46,6 +46,15 @@ class CommandsMixin:
         """Normalize response to a dict or list."""
         raise NotImplementedError
 
+    def _flag_ota_if_started(self, response: Any) -> None:
+        """Flag OTA as active if response indicates firmware update has started."""
+        normalized = self._normalize_response(response)
+        if isinstance(normalized, dict) and (
+            normalized.get("msg") == "started"
+            or normalized.get("msg") in SUCCESS_ANSWERS
+        ):
+            self._status["ota_update"] = 1
+
     async def get_schedule(self) -> Mapping[str, Any] | list[Any]:
         """Return the current schedule."""
         url = f"{self.url}schedule"
@@ -476,12 +485,7 @@ class CommandsMixin:
             response = await self.process_request(
                 url=url, method="post", rapi=form_data
             )
-            normalized = self._normalize_response(response)
-            if isinstance(normalized, dict) and (
-                normalized.get("msg") == "started"
-                or normalized.get("msg") in SUCCESS_ANSWERS
-            ):
-                self._status["ota_update"] = 1
+            self._flag_ota_if_started(response)
             return response
 
         # 2. Resolve URL from GitHub if not specified
@@ -499,12 +503,7 @@ class CommandsMixin:
             "Requesting OpenEVSE to download and update from: %s", firmware_url
         )
         response = await self.process_request(url=url, method="post", data=data)
-        normalized = self._normalize_response(response)
-        if isinstance(normalized, dict) and (
-            normalized.get("msg") == "started"
-            or normalized.get("msg") in SUCCESS_ANSWERS
-        ):
-            self._status["ota_update"] = 1
+        self._flag_ota_if_started(response)
         return response
 
     async def set_led_brightness(self, level: int) -> None:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,7 +5,7 @@ pytest-cov==7.1.0
 pytest-timeout==2.4.0
 pytest-asyncio
 requests_mock
-aiohttp
+aiohttp<3.11
 aioresponses
 tox==4.55.0
 freezegun

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -117,6 +117,55 @@ async def test_get_status_auth_err(test_charger_auth_err):
         await test_charger_auth_err.update()
 
 
+async def test_update_force_status(mock_aioclient):
+    """Test force_status parameter when ws is listening."""
+    unique_host = "force-status.test.tld"
+    charger = OpenEVSE(unique_host)
+    url_status = f"http://{unique_host}/status"
+    url_config = f"http://{unique_host}/config"
+
+    mock_aioclient.get(
+        url_status,
+        status=200,
+        body='{"state": 2, "wifi_serial": "123"}',
+    )
+    mock_aioclient.get(
+        url_config,
+        status=200,
+        body='{"wifi_serial": "123", "version": "4.0.1"}',
+    )
+    charger._ws_listening = True
+    charger._status = {"transient_key": "preserved"}
+    await charger.update(force_status=True)
+    assert charger._status["state"] == 2
+    assert charger._status["transient_key"] == "preserved"
+
+
+async def test_update_ota_active(mock_aioclient):
+    """Test automatic status polling when ota_update is active."""
+    unique_host = "ota-active.test.tld"
+    charger = OpenEVSE(unique_host)
+    url_status = f"http://{unique_host}/status"
+    url_config = f"http://{unique_host}/config"
+
+    mock_aioclient.get(
+        url_status,
+        status=200,
+        body='{"state": 2, "ota_update": 1}',
+    )
+    mock_aioclient.get(
+        url_config,
+        status=200,
+        body='{"wifi_serial": "123", "version": "4.0.1"}',
+    )
+    charger._ws_listening = True
+    charger._status = {"ota_update": 1, "ota_progress": 50}
+    await charger.update()
+    assert charger._status["state"] == 2
+    assert charger._status["ota_progress"] == 50
+    assert charger.ota_update is True
+
+
 # ── send_command ──────────────────────────────────────────────────────
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1060,6 +1060,7 @@ async def test_update_firmware_bytes(test_charger, mock_aioclient, caplog):
             "Uploading firmware binary to http://openevse.test.tld/update (14 bytes)"
             in caplog.text
         )
+        assert test_charger.ota_update is True
 
 
 async def test_update_firmware_url(test_charger, mock_aioclient, caplog):
@@ -1079,6 +1080,7 @@ async def test_update_firmware_url(test_charger, mock_aioclient, caplog):
             "Requesting OpenEVSE to download and update from: http://github.com/release.bin"
             in caplog.text
         )
+        assert test_charger.ota_update is True
 
 
 async def test_update_firmware_auto(test_charger, mock_aioclient, caplog):
@@ -1122,6 +1124,7 @@ async def test_update_firmware_auto(test_charger, mock_aioclient, caplog):
             "Requesting OpenEVSE to download and update from: https://github.com/OpenEVSE/releases/download/v4.1.2/openevse_esp32-gateway.bin"
             in caplog.text
         )
+        assert test_charger.ota_update is True
 
 
 async def test_update_firmware_auto_missing_buildenv(test_charger, mock_aioclient):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1186,3 +1186,19 @@ async def test_update_firmware_unsupported(test_charger):
     test_charger._config["version"] = "4.1.2"
     with pytest.raises(UnsupportedFeature):
         await test_charger.update_firmware(firmware_url="http://url")
+
+
+async def test_update_firmware_error_response(test_charger, mock_aioclient):
+    """Test update_firmware doesn't set ota_update on error responses."""
+    test_charger._config["version"] = "4.1.7"
+    test_charger._status = {}
+    mock_aioclient.post(
+        "http://openevse.test.tld/update",
+        status=200,
+        body='{"msg":"error"}',
+    )
+    response = await test_charger.update_firmware(
+        firmware_url="http://github.com/release.bin"
+    )
+    assert response == {"msg": "error"}
+    assert test_charger.ota_update is False


### PR DESCRIPTION
Addresses #597

This PR adds support for forcing status updates and handles status polling automatically during OTA firmware updates when the WebSocket connection is active:

1. Modifies `update()` to accept a `force_status` parameter to force polling `/status` even when WebSocket listening is active.
2. Automatically triggers `/status` polling in `update()` if an OTA update is currently running (`self.ota_update` is True).
3. Changes the internal status dict update to use `.update()` instead of overwriting, preserving transient status properties (like `ota_progress`) received via WebSocket.
4. Automatically flags `ota_update` as active (`1`) upon triggering `update_firmware()`.
5. Adds unit tests for the new behaviors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `force_status` parameter to enable manual status refresh even when websocket listening is active.

* **Bug Fixes**
  * Status updates now merge with existing data instead of replacing it entirely, preserving transient information.
  * Firmware update operations now properly track OTA progress initialization.

* **Tests**
  * Added test coverage for forced status updates and OTA tracking behavior.

* **Chores**
  * Constrained aiohttp dependency to versions below 3.11.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->