### PR TITLE
typing: Clean up service_level and make constructor easier

### DIFF
--- a/openevsehttp/client.py
+++ b/openevsehttp/client.py
@@ -50,13 +50,13 @@ class OpenEVSE(CommandsMixin, ManagersMixin, SensorsMixin, PropertiesMixin):
     def __init__(
         self,
         host: str,
-        user: str = "",
-        pwd: str = "",
+        user: str | None = None,
+        pwd: str | None = None,
         session: aiohttp.ClientSession | None = None,
     ) -> None:
         """Connect to an OpenEVSE charger equipped with wifi or ethernet."""
-        self._user = user
-        self._pwd = pwd
+        self._user = user or ""
+        self._pwd = pwd or ""
         self.url = f"http://{host}/"
         self._status: dict[str, Any] = {}
         self._config: dict[str, Any] = {}

--- a/openevsehttp/properties.py
+++ b/openevsehttp/properties.py
@@ -84,8 +84,8 @@ class PropertiesMixin:
         return bool(self._config.get("relayt", False))
 
     @property
-    def service_level(self) -> int | str | None:
-        """Return the service level (1, 2, or 'A')."""
+    def service_level(self) -> str | None:
+        """Return the service level ('1', '2', or 'A')."""
         return self._config.get("service")
 
     @property

--- a/openevsehttp/properties.py
+++ b/openevsehttp/properties.py
@@ -86,7 +86,10 @@ class PropertiesMixin:
     @property
     def service_level(self) -> str | None:
         """Return the service level ('1', '2', or 'A')."""
-        return self._config.get("service")
+        value = self._config.get("service")
+        if value is None:
+            return value
+        return str(value)
 
     @property
     def openevse_firmware(self) -> str | None:

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -56,8 +56,8 @@ SERVER_URL = "openevse.test.tld"
         ("test_charger_v2", "ammeter_offset", 0),
         ("test_charger", "ammeter_scale_factor", 220),
         ("test_charger_v2", "ammeter_scale_factor", 220),
-        ("test_charger", "service_level", 2),
-        ("test_charger_v2", "service_level", 2),
+        ("test_charger", "service_level", "2"),
+        ("test_charger_v2", "service_level", "2"),
         # safety checks
         ("test_charger", "temp_check_enabled", False),
         ("test_charger_v2", "temp_check_enabled", False),


### PR DESCRIPTION
This cleans up a couple things that make using the integration a bit rougher.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed service level property to consistently return string values or None instead of mixed integer/string types.

* **API Changes**
  * Authentication credentials are now optional and can accept None values instead of requiring default empty strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->