### PR TITLE
feat(utils): support category/branch_hash_modified dev version template

### DIFF
--- a/openevsehttp/utils.py
+++ b/openevsehttp/utils.py
@@ -32,7 +32,9 @@ def get_awesome_version(version: str) -> AwesomeVersion:
     # We use custom word boundary checks to avoid false positives like 'domain' matching 'main'
     # or 'webmaster' matching 'master'.
     is_dev = False
-    if re.search(
+    if re.search(r"[^/]+/[^_]+_[a-fA-F0-9]{6,40}_modified$", version, re.IGNORECASE):
+        is_dev = True
+    elif re.search(
         r"(?:^|[^a-zA-Z0-9])(master|main)(?:[^a-zA-Z0-9]|$)", version, re.IGNORECASE
     ):
         is_dev = True

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -671,12 +671,25 @@ async def test_version_check_dev_branches():
     charger._config = {"version": "feature_1A2B3C"}
     assert charger._version_check("2.0.0") is True
 
+    # Local dev build templates (category/branch_hash_modified) - treated as dev, returns True
+    charger._config = {
+        "version": "local_feature/gui-nightshift-default_2bcdf1d0_modified"
+    }
+    assert charger._version_check("2.0.0") is True
+
+    charger._config = {"version": "custom_branch/my-feature_abc123_modified"}
+    assert charger._version_check("2.0.0") is True
+
     # False positives containing 'main' or 'master' but not at word boundaries,
-    # or ending in 6-char hashes without dev keywords — should fail version check
+    # ending in 6-char hashes without dev keywords, or other non-matching modified strings
+    # — should fail version check
     charger._config = {"version": "domain_abc123"}
     assert charger._version_check("2.0.0") is False
 
     charger._config = {"version": "webmaster_def456"}
+    assert charger._version_check("2.0.0") is False
+
+    charger._config = {"version": "unmodified"}
     assert charger._version_check("2.0.0") is False
 
     # Pre-release (rc) version — should fail when checking against a newer target


### PR DESCRIPTION
This PR adds support for matching locally compiled dev build version strings (e.g. `local_feature/gui-nightshift-default_2bcdf1d0_modified`) to ensure features are not disabled under custom local builds.

Related to https://github.com/firstof9/openevse/issues/642

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced version detection to properly recognize additional modified and custom branch version formats as development builds, improving the system's handling of non-standard version strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->