### PR TITLE
feat(utils): support any dev firmware version ending with _modified

### DIFF
--- a/openevsehttp/utils.py
+++ b/openevsehttp/utils.py
@@ -32,7 +32,7 @@ def get_awesome_version(version: str) -> AwesomeVersion:
     # We use custom word boundary checks to avoid false positives like 'domain' matching 'main'
     # or 'webmaster' matching 'master'.
     is_dev = False
-    if re.search(r"[^/]+/[^_]+_[a-fA-F0-9]{6,40}_modified$", version, re.IGNORECASE):
+    if re.search(r"_modified$", version, re.IGNORECASE):
         is_dev = True
     elif re.search(
         r"(?:^|[^a-zA-Z0-9])(master|main)(?:[^a-zA-Z0-9]|$)", version, re.IGNORECASE

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -671,13 +671,16 @@ async def test_version_check_dev_branches():
     charger._config = {"version": "feature_1A2B3C"}
     assert charger._version_check("2.0.0") is True
 
-    # Local dev build templates (category/branch_hash_modified) - treated as dev, returns True
+    # Suffix matching for _modified - treated as dev, returns True
     charger._config = {
         "version": "local_feature/gui-nightshift-default_2bcdf1d0_modified"
     }
     assert charger._version_check("2.0.0") is True
 
     charger._config = {"version": "custom_branch/my-feature_abc123_modified"}
+    assert charger._version_check("2.0.0") is True
+
+    charger._config = {"version": "main_modified"}
     assert charger._version_check("2.0.0") is True
 
     # False positives containing 'main' or 'master' but not at word boundaries,


### PR DESCRIPTION
This PR adds support for matching any locally compiled or modified firmware version string ending with `_modified` (e.g. `local_feature/gui-nightshift-default_2bcdf1d0_modified` or `main_modified`) to classify them as dev firmware.