### PR TITLE
feat: support HTTPS connections and SSL verification bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ async def main():
 if __name__ == "__main__":
     asyncio.run(main())
 ```
+### HTTPS and SSL Verification Options
+
+If your OpenEVSE WiFi/ethernet module uses HTTPS (e.g. with a self-signed certificate), you can initialize the client with `ssl=True` and configure SSL verification:
+
+```python
+        # Connect using HTTPS, and disable certificate verification
+        charger = OpenEVSE(
+            "192.168.1.30",
+            session=session,
+            ssl=True,
+            ssl_verify=False,
+        )
+```
 
 ## API Support Matrix
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,23 @@ if __name__ == "__main__":
 ```
 ### HTTPS and SSL Verification Options
 
-If your OpenEVSE WiFi/ethernet module uses HTTPS (e.g. with a self-signed certificate), you can initialize the client with `ssl=True` and configure SSL verification:
+If your OpenEVSE WiFi/ethernet module uses HTTPS, you can configure the client to connect securely using the `ssl=True` parameter:
+
+```python
+        # Connect securely using HTTPS (validating SSL/TLS certificates)
+        charger = OpenEVSE(
+            "192.168.1.30",
+            session=session,
+            ssl=True,
+        )
+```
+
+#### Bypassing SSL Verification (Self-Signed Certificates)
+
+> [!WARNING]
+> Disabling SSL certificate validation (`ssl_verify=False`) disables TLS verification and exposes the connection to Man-in-the-Middle (MITM) attacks. Only use this configuration when connecting to an OpenEVSE module with a self-signed certificate over a trusted local network.
+
+To bypass certificate verification:
 
 ```python
         # Connect using HTTPS, and disable certificate verification

--- a/example_external_session.py
+++ b/example_external_session.py
@@ -69,4 +69,4 @@ async def example_with_https_and_ssl_bypass():
 
 if __name__ == "__main__":
     # Run one of the examples
-    asyncio.run(example_with_https_and_ssl_bypass())
+    asyncio.run(example_with_external_session())

--- a/example_external_session.py
+++ b/example_external_session.py
@@ -49,6 +49,24 @@ async def example_shared_session():
         await charger2.ws_disconnect()
 
 
+async def example_with_https_and_ssl_bypass():
+    """Demonstrate using HTTPS with bypassed SSL verification."""
+    async with aiohttp.ClientSession() as session:
+        # Pass ssl=True to construct an https:// URL,
+        # and ssl_verify=False to bypass certificate validation.
+        charger = OpenEVSE(
+            "192.168.1.30",
+            session=session,
+            ssl=True,
+            ssl_verify=False,
+        )
+
+        # Use the charger normally
+        await charger.update()
+        print(f"Status: {charger.status}")
+        await charger.ws_disconnect()
+
+
 if __name__ == "__main__":
     # Run one of the examples
-    asyncio.run(example_with_external_session())
+    asyncio.run(example_with_https_and_ssl_bypass())

--- a/openevsehttp/client.py
+++ b/openevsehttp/client.py
@@ -53,11 +53,16 @@ class OpenEVSE(CommandsMixin, ManagersMixin, SensorsMixin, PropertiesMixin):
         user: str | None = None,
         pwd: str | None = None,
         session: aiohttp.ClientSession | None = None,
+        ssl: bool = False,
+        ssl_verify: bool = True,
     ) -> None:
         """Connect to an OpenEVSE charger equipped with wifi or ethernet."""
         self._user = user or ""
         self._pwd = pwd or ""
-        self.url = f"http://{host}/"
+        self.ssl = ssl
+        self.ssl_verify = ssl_verify
+        scheme = "https" if ssl else "http"
+        self.url = f"{scheme}://{host}/"
         self._status: dict[str, Any] = {}
         self._config: dict[str, Any] = {}
         self._override: Any = None
@@ -134,6 +139,8 @@ class OpenEVSE(CommandsMixin, ManagersMixin, SensorsMixin, PropertiesMixin):
             kwargs = {"data": rapi, "auth": auth}
             if data is not None:
                 kwargs["json"] = data
+            if url.startswith("https://") and not self.ssl_verify:
+                kwargs["ssl"] = False
             async with http_method(url, **kwargs) as resp:
                 try:
                     raw = await resp.text()
@@ -285,6 +292,7 @@ class OpenEVSE(CommandsMixin, ManagersMixin, SensorsMixin, PropertiesMixin):
             self._user,
             self._pwd,
             self._session,
+            ssl_verify=self.ssl_verify,
         )
 
     def _validate_session_loop(self, loop: asyncio.AbstractEventLoop) -> None:

--- a/openevsehttp/commands.py
+++ b/openevsehttp/commands.py
@@ -436,10 +436,7 @@ class CommandsMixin:
             url,
             method,
         )
-        kwargs: dict[str, Any] = {}
-        if url.startswith("https://") and not self.ssl_verify:
-            kwargs["ssl"] = False
-        async with http_method(url, **kwargs) as resp:
+        async with http_method(url) as resp:
             _LOGGER.debug("Firmware check response status: %d", resp.status)
             if resp.status != 200:
                 return None

--- a/openevsehttp/commands.py
+++ b/openevsehttp/commands.py
@@ -23,6 +23,8 @@ class CommandsMixin:
     """Mixin providing command methods for OpenEVSE."""
 
     url: str
+    ssl: bool
+    ssl_verify: bool
     _status: dict[str, Any]
     _config: dict[str, Any]
     _session: aiohttp.ClientSession | None
@@ -434,7 +436,10 @@ class CommandsMixin:
             url,
             method,
         )
-        async with http_method(url) as resp:
+        kwargs: dict[str, Any] = {}
+        if url.startswith("https://") and not self.ssl_verify:
+            kwargs["ssl"] = False
+        async with http_method(url, **kwargs) as resp:
             _LOGGER.debug("Firmware check response status: %d", resp.status)
             if resp.status != 200:
                 return None

--- a/openevsehttp/websocket.py
+++ b/openevsehttp/websocket.py
@@ -42,9 +42,11 @@ class OpenEVSEWebsocket:
         user: str | None = None,
         password: str | None = None,
         session: aiohttp.ClientSession | None = None,
+        ssl_verify: bool = True,
     ) -> None:
         """Initialize a OpenEVSEWebsocket instance."""
         self.session = session
+        self.ssl_verify = ssl_verify
         self.uri = self._get_uri(server)
         self._user = user
         self._password = password
@@ -133,10 +135,16 @@ class OpenEVSEWebsocket:
         try:
             # Narrow type for mypy since _ensure_session sets self.session
             assert self.session is not None
+            ws_kwargs: dict[str, Any] = {
+                "heartbeat": 15,
+                "auth": auth,
+            }
+            if self.uri.startswith("wss://") and not self.ssl_verify:
+                ws_kwargs["ssl"] = False
+
             async with self.session.ws_connect(
                 self.uri,
-                heartbeat=15,
-                auth=auth,
+                **ws_kwargs,
             ) as ws_client:
                 self._client = ws_client
                 await self._set_state(STATE_CONNECTED)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1887,3 +1887,44 @@ async def test_get_session_no_running_loop_mocked(charger_factory):
     charger = charger_factory()
     with patch("asyncio.get_running_loop", side_effect=RuntimeError):
         assert charger._get_session() is charger._session
+
+
+async def test_ssl_options(mock_aioclient):
+    """Test SSL options and SSL verification configuration."""
+    # 1. Default (ssl=False, ssl_verify=True)
+    charger_default = OpenEVSE(SERVER_URL, session=MockClientSession(mock_aioclient))
+    assert charger_default.url == f"http://{SERVER_URL}/"
+    assert charger_default.ssl is False
+    assert charger_default.ssl_verify is True
+
+    # 2. Secure connection (ssl=True, ssl_verify=True)
+    charger_ssl = OpenEVSE(
+        SERVER_URL, ssl=True, session=MockClientSession(mock_aioclient)
+    )
+    assert charger_ssl.url == f"https://{SERVER_URL}/"
+    assert charger_ssl.ssl is True
+    assert charger_ssl.ssl_verify is True
+
+    # 3. Secure connection with disabled validation (ssl=True, ssl_verify=False)
+    charger_no_verify = OpenEVSE(
+        SERVER_URL,
+        ssl=True,
+        ssl_verify=False,
+        session=MockClientSession(mock_aioclient),
+    )
+    assert charger_no_verify.url == f"https://{SERVER_URL}/"
+    assert charger_no_verify.ssl is True
+    assert charger_no_verify.ssl_verify is False
+
+    # Check request parameter passing
+    url = f"https://{SERVER_URL}/status"
+    mock_aioclient.get(url, status=200, body='{"state": "sleeping"}')
+
+    # When ssl_verify=False, ssl=False should be passed to session request kwargs
+    await charger_no_verify.process_request(url, method="get")
+    assert mock_aioclient.requests[-1][2].get("ssl") is False
+
+    # When ssl_verify=True, ssl should NOT be passed as False
+    mock_aioclient.get(url, status=200, body='{"state": "sleeping"}')
+    await charger_ssl.process_request(url, method="get")
+    assert "ssl" not in mock_aioclient.requests[-1][2]

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -548,3 +548,55 @@ async def test_websocket_close_cancels_pending_tasks(ws_client):
     # Close should cancel and drain tasks
     await ws_client.close()
     assert len(ws_client._tasks) == 0
+
+
+@pytest.mark.asyncio
+async def test_websocket_ssl_options(mock_callback):
+    """Test OpenEVSEWebsocket SSL options and ws_connect parameter passing."""
+    async with aiohttp.ClientSession() as session:
+        # Default ssl_verify=True
+        ws_default = OpenEVSEWebsocket(
+            "https://openevse.test.tld/",
+            mock_callback,
+            session=session,
+        )
+        assert ws_default.ssl_verify is True
+        assert ws_default.uri == "wss://openevse.test.tld/ws"
+
+        # Explicit ssl_verify=False
+        ws_no_verify = OpenEVSEWebsocket(
+            "https://openevse.test.tld/",
+            mock_callback,
+            session=session,
+            ssl_verify=False,
+        )
+        assert ws_no_verify.ssl_verify is False
+        assert ws_no_verify.uri == "wss://openevse.test.tld/ws"
+
+        # Mock ws_connect to check that it is called with ssl=False when ssl_verify=False
+        mock_ws = AsyncMock()
+        mock_ws.__aenter__ = AsyncMock(return_value=mock_ws)
+        mock_ws.__aexit__ = AsyncMock(return_value=None)
+
+        async def empty_iter():
+            return
+            yield
+
+        mock_ws.__aiter__.side_effect = empty_iter
+
+        with patch(
+            "aiohttp.ClientSession.ws_connect", return_value=mock_ws
+        ) as mock_connect:
+            await ws_no_verify.running()
+            mock_connect.assert_called_once()
+            call_kwargs = mock_connect.call_args.kwargs
+            assert call_kwargs.get("ssl") is False
+
+        # When ssl_verify=True, ws_connect should NOT pass ssl=False
+        with patch(
+            "aiohttp.ClientSession.ws_connect", return_value=mock_ws
+        ) as mock_connect:
+            await ws_default.running()
+            mock_connect.assert_called_once()
+            call_kwargs = mock_connect.call_args.kwargs
+            assert "ssl" not in call_kwargs


### PR DESCRIPTION
## Summary
Adds support for HTTPS connections to the OpenEVSE charger and introduces options to bypass SSL certificate validation for both HTTP requests and WebSocket connections.

## Details
- **OpenEVSE Client**: Updated constructor to accept optional `ssl: bool = False` and `ssl_verify: bool = True` parameters. Constructs `self.url` with the `https` scheme when `ssl` is `True` and `http` otherwise.
- **Request Processing**: Updates `_process_request_with_session` in `OpenEVSE` and `_firmware_check_with_session` in `CommandsMixin` to pass `ssl=False` to `aiohttp` requests when using HTTPS with disabled SSL certificate validation.
- **WebSocket Listener**: Updated `OpenEVSEWebsocket` constructor to receive `ssl_verify` and pass `ssl=False` to `session.ws_connect` when using a secure WebSocket (`wss://`) with validation bypassed.
- **Examples & Docs**: Added a code demonstration to `example_external_session.py` and updated `README.md` to document the new `ssl` and `ssl_verify` parameters.

## Testing
- Added `test_ssl_options` in `tests/test_client.py` covering url construction and `ssl=False` request kwarg passing.
- Added `test_websocket_ssl_options` in `tests/test_websocket.py` covering secure websocket uri construction and parameter passing.
- Ran test suite locally (all 423 tests passed).

## Context
Enables connecting to OpenEVSE modules running secure local servers with self-signed SSL/TLS certificates, laying the groundwork for secure downstream integration in systems like Home Assistant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenEVSE client now supports HTTPS configuration with adjustable SSL certificate verification settings.

* **Documentation**
  * Added HTTPS/SSL configuration documentation and example demonstrating certificate verification control.

* **Tests**
  * Added test coverage for SSL options and websocket SSL behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->