### PR TITLE
ci: install lint dependencies from requirements_lint.txt in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.14"
-      - name: Install prek
-        run: pip install prek==0.4.0
+      - name: Install dependencies
+        run: pip install -r requirements_lint.txt
       - name: Run prek
         run: prek run --all-files --skip no-commit-to-branch
   build:

--- a/EXTERNAL_SESSION.md
+++ b/EXTERNAL_SESSION.md
@@ -19,6 +19,7 @@ The `python-openevse-http` library requires you to pass an external `aiohttp.Cli
 import aiohttp
 from openevsehttp import OpenEVSE
 
+
 async def main():
     timeout = aiohttp.ClientTimeout(total=30)
     async with aiohttp.ClientSession(timeout=timeout) as session:
@@ -33,6 +34,7 @@ async def main():
 ```python
 import aiohttp
 from openevsehttp import OpenEVSE
+
 
 async def main():
     async with aiohttp.ClientSession() as session:
@@ -51,6 +53,7 @@ Start websocket listening from the same event loop that owns the
 ```python
 import aiohttp
 from openevsehttp import OpenEVSE
+
 
 async def main():
     async with aiohttp.ClientSession() as session:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ import asyncio
 import aiohttp
 from openevsehttp import OpenEVSE
 
+
 async def main():
     async with aiohttp.ClientSession() as session:
         charger = OpenEVSE("192.168.1.30", session=session)
@@ -47,6 +48,7 @@ async def main():
 
         await charger.toggle_shaper()
         await charger.ws_disconnect()
+
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Description

Update `.github/workflows/test.yml` to install linting dependencies from `requirements_lint.txt` instead of hardcoding an outdated `prek` version.

## Motivation and Context
This keeps the test workflow in sync with dependency updates to `requirements_lint.txt`.

## How Has This Been Tested?
- Ran `prek run --all-files --skip no-commit-to-branch` locally.
